### PR TITLE
added toggle option

### DIFF
--- a/keylight/cli.py
+++ b/keylight/cli.py
@@ -22,17 +22,17 @@ def parse() -> types.Flags:
                         help=f'{constants.MIN_BRIGHTNESS} <= brightness <= {constants.MAX_BRIGHTNESS}')
     parser.add_argument('-c', '--color', type=int, help='2900 <= color temperature <= 6987')
     parser.add_argument('--host', help='hostname of the Key Light (omit to use auto-discovery)')
-    parser.add_argument('--on', action='store_true', help='turn the Key Light on')
-    parser.add_argument('--off', action='store_true', help='turn the Key Light off')
+    power_group = parser.add_mutually_exclusive_group()
+    power_group.add_argument('--on', action='store_true', help='turn the Key Light on')
+    power_group.add_argument('--off', action='store_true', help='turn the Key Light off')
+    power_group.add_argument('--toggle', action='store_true', help='toggle the Key Light on/off')
     args = parser.parse_args()
-    if args.on and args.off:
-        print('--on and --off flags are mutually exclusive', file=sys.stderr)
-        exit(1)
     return types.Flags(
         brightness=_normalize('Brightness', args.brightness, constants.MIN_BRIGHTNESS, constants.MAX_BRIGHTNESS),
         color=_normalize('Color', args.color, constants.MIN_COLOR, constants.MAX_COLOR),
         host=args.host,
         on=args.on,
         off=args.off,
+        toggle=args.toggle,
         port=constants.DEFAULT_PORT,
     )

--- a/keylight/main.py
+++ b/keylight/main.py
@@ -41,6 +41,11 @@ def _main(flags: types.Flags):
         light.on()
     if flags.off:
         light.off()
+    if flags.toggle:
+        if light.isOn:
+            light.off()
+        else:
+            light.on()
     print(textwrap.dedent(f'''\
         Brightness: {light.isBrightness}%
         Color temperature: {light.isTemperature:.0f}k

--- a/keylight/types.py
+++ b/keylight/types.py
@@ -8,4 +8,5 @@ class Flags:
     host: str
     off: bool
     on: bool
+    toggle: bool
     port: int


### PR DESCRIPTION
Added a `--toggle` option that checks the current on/off state of the light and switch it.

Also used `mutually_exclusive_group` to not have to manually check if more than one of on, off, or toggle were given.

Addresses: https://github.com/andornaut/keylight/issues/1